### PR TITLE
Fix variable typos

### DIFF
--- a/host_vars/localhost/defaults.yml
+++ b/host_vars/localhost/defaults.yml
@@ -204,7 +204,7 @@ required_parameters:
 - vcpus
 - memory_mb
 - disk_size
-- image_soruce
+- image_source
 #note: supplying cloud-init file is optional, the playbook would rander it's own file
 
 #following binaries are required on the controller machine

--- a/roles/vm_creator/tasks/main.yml
+++ b/roles/vm_creator/tasks/main.yml
@@ -72,7 +72,7 @@
                  {%-endif-%}
              {%- elif image_download_stats_non_checksumed is defined -%}
                  {%- if image_download_stats_non_checksumed.msg is defined -%}
-                     {%- if image_download_stats_not_checksumed.msg|regex_search('^OK') -%}
+                    {%- if image_download_stats_non_checksumed.msg|regex_search('^OK') -%}
                          {{ true|bool }}
                      {%-else-%}
                          {{ false |bool }}


### PR DESCRIPTION
## Summary
- fix variable name in defaults list
- fix typo in VM image download check

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684612f117b0832f9a83f53b62b39fa2